### PR TITLE
WIP to port lisp-parser.dart

### DIFF
--- a/src/commonTest/kotlin/org/petitparser/grammar/lisp/Lisp.kt
+++ b/src/commonTest/kotlin/org/petitparser/grammar/lisp/Lisp.kt
@@ -1,0 +1,71 @@
+package org.petitparser.grammar.lisp
+
+import org.petitparser.core.grammar.Grammar
+import org.petitparser.core.parser.Parser
+import org.petitparser.core.parser.combinator.*
+import org.petitparser.core.parser.consumer.CharPredicate.Companion.any
+import org.petitparser.core.parser.consumer.CharPredicate.Companion.anyOf
+import org.petitparser.core.parser.consumer.CharPredicate.Companion.char
+import org.petitparser.core.parser.consumer.CharPredicate.Companion.pattern
+import org.petitparser.core.parser.consumer.digit
+import org.petitparser.core.parser.consumer.newline
+import org.petitparser.core.parser.consumer.whitespace
+import org.petitparser.core.parser.misc.end
+import org.petitparser.core.parser.repeater.star
+
+class LispGrammar : Grammar() {
+
+  private val comment by seq(char(';'), newline().not().star())
+  private val space by or(whitespace(), ref(comment))
+
+  private val splice by seq(char('@'), list)
+  private val unquote by seq(char(','), ref(list))
+  private val quasiquote by seq(char('`'), ref(list))
+  private val quote by seq(char('\''), ref(atom))
+
+  private val symbolToken by seqMap(
+    pattern("a-zA-Z!#\$%&*/:<=>?@\\^_|~+-"),
+    pattern("a-zA-Z0-9!#\$%&*/:<=>?@\\^_|~+-")).star()
+  private val symbol = symbolToken.flatten("Symbol expected")
+
+  private val characterRaw = pattern("^\"")
+  private val characterEscape by seqMap(char('\\'), any())
+  private val character by or(ref(characterEscape), ref(characterRaw))
+  private val `string` by seq(
+    char('"'),
+    character.star(),
+    char('"')) { _, it, _ -> it}
+
+
+  private val empty = ref(space).star()
+  private val cell by seq(atom, cells)
+  private val cells by or(ref(cell), ref(empty))
+
+  private val numberToken by seqMap(
+  ref(anyOf("-+")).optional(),
+  char('0') or digit().plus(),
+  char('.').seq(digit().plus()).optional() &
+  anyOf('eE').seq(anyOf('-+').optional()).seq(digit().plus()).optional()
+  )
+  private val number = ref(numberToken).flatten("Number expected")
+
+  private val list by seqMap(
+    char('('),
+    cell,
+    char(')'),
+  ) { _, it, _ -> it.elements }
+
+
+  private val atomChoice: Parser<Any?> by or(
+    list,
+    number,
+    string,
+    symbol,
+    quote,
+    quasiquote,
+    unquote,
+    splice
+  )
+
+  val start by atomChoice.star().end()
+}


### PR DESCRIPTION
A few months ago, I wanted to learn Kotlin and thought it'd be a good exercise to port the Lisp parser in dart-petitparser over to Kotlin.

But I don't really know Kotlin and the use of the `by` operator felt quite mysterious to me. I think I spent 2 evenings on this, and what I ended with doesn't compile.

In terms of API, I remember thinking that java-petitparser's API seems a lot more similar than kotlin-petitparser. Since I'm targeting the JVM, I wondered what the difference is using java-petitparser in kotlin vs. using kotlin-petitparser.

I was reminded of this little experiment and wanted to get it moving forward, so I'm opening a draft PR to see if I could get some help or tips to getting this port completed.

Thanks!